### PR TITLE
Option to write #summary pragma as italics 

### DIFF
--- a/wiki_to_md/impl/pragma_handler.py
+++ b/wiki_to_md/impl/pragma_handler.py
@@ -17,24 +17,25 @@
 class PragmaHandler(object):
   """Class that handles the conversion of pragmas."""
 
-  def __init__(self, warning_method):
+  def __init__(self, warning_method, summary_italic):
     """Create a pragma handler.
 
     Args:
         warning_method: A function to call to display a warning message.
     """
     self._warning_method = warning_method
+    self._summary_italic = summary_italic
 
   def HandlePragma(self,
                    input_line,
-                   unused_output_stream,
+                   output_stream,
                    pragma_type,
                    pragma_value):
     """Handle a parsed pragma directive.
 
     Args:
         input_line: The line number this match occurred on.
-        unused_output_stream: Output Markdown file.
+        output_stream: Output Markdown file.
         pragma_type: The pragma's type.
         pragma_value: The pragma's value, trimmed.
     """
@@ -42,12 +43,15 @@ class PragmaHandler(object):
     # Google Code supports, so simply notify the user a pragma
     # was matched and that they might want to do something about it.
     if pragma_type == "summary":
-      self._warning_method(
-          input_line,
-          u"A summary pragma was used for this wiki:\n"
-          "\t{0}\n"
-          "Consider moving it to an introductory paragraph."
-          .format(pragma_value))
+      if not self._summary_italic:
+        self._warning_method(
+            input_line,
+            u"A summary pragma was used for this wiki:\n"
+            "\t{0}\n"
+            "Consider moving it to an introductory paragraph."
+            .format(pragma_value))
+      else:
+        output_stream.write("*{0}*\n\n".format(pragma_value))
     elif pragma_type == "sidebar":
       self._warning_method(
           input_line,

--- a/wiki_to_md/wiki2gfm.py
+++ b/wiki_to_md/wiki2gfm.py
@@ -78,6 +78,8 @@ def main(args):
                       action="store_true", help=symmetric_headers_help)
   parser.add_argument("--no_symmetric_headers", dest="symmetric_headers",
                       action="store_false", help=symmetric_headers_help)
+  parser.add_argument("--summary_italic", dest="summary_italic",
+                      action="store_true", help="convert #summary to italic")
   parser.set_defaults(feature=False)
 
   parsed_args, unused_unknown_args = parser.parse_known_args(args)
@@ -100,7 +102,9 @@ def main(args):
       issue_map = {}
 
       # Prepare the handlers and converter.
-      pragma_handler = PragmaHandler(PrintWarning)
+      pragma_handler = PragmaHandler(
+          PrintWarning,
+          parsed_args.summary_italic)
       formatting_handler = FormattingHandler(
           PrintWarning,
           parsed_args.project,

--- a/wiki_to_md/wiki2gfm.py
+++ b/wiki_to_md/wiki2gfm.py
@@ -30,9 +30,9 @@ import codecs
 import os
 import sys
 
-from impl import converter as converter_mod
-from impl import formatting_handler as formatting_handler_mod
-from impl import pragma_handler as pragma_handler_mod
+from impl.converter import Converter
+from impl.formatting_handler import FormattingHandler
+from impl.pragma_handler import PragmaHandler
 
 
 def PrintWarning(input_line, message):
@@ -100,13 +100,13 @@ def main(args):
       issue_map = {}
 
       # Prepare the handlers and converter.
-      pragma_handler = pragma_handler_mod.PragmaHandler(PrintWarning)
-      formatting_handler = formatting_handler_mod.FormattingHandler(
+      pragma_handler = PragmaHandler(PrintWarning)
+      formatting_handler = FormattingHandler(
           PrintWarning,
           parsed_args.project,
           issue_map,
           parsed_args.symmetric_headers)
-      converter = converter_mod.Converter(
+      converter = Converter(
           pragma_handler,
           formatting_handler,
           PrintWarning,


### PR DESCRIPTION
Add option `--summary_italic` that makes converter write page summary in italics on top of the page.

This is PR #186, just moved from master to feature branch.
